### PR TITLE
SMILE-1357-expand_all_searches_automatic

### DIFF
--- a/src/Components/Contributors/ContributorSearchPanel.tsx
+++ b/src/Components/Contributors/ContributorSearchPanel.tsx
@@ -81,8 +81,6 @@ export interface AddAffiliationError extends Error {
   institutionId: string;
 }
 
-const MaxContributorsToSearchAutomatic = 50;
-
 interface ContributorSearchPanelProps {
   resultListIndex: number;
   contributorData: ContributorWrapper;
@@ -110,11 +108,7 @@ const ContributorSearchPanel: FC<ContributorSearchPanelProps> = ({
   }, [contributorData.toBeCreated.affiliations]);
 
   useEffect(() => {
-    if (
-      contributorData.toBeCreated.badge_type !== ContributorStatus.Verified &&
-      contributorData.toBeCreated.order &&
-      contributorData.toBeCreated.order <= MaxContributorsToSearchAutomatic
-    ) {
+    if (contributorData.toBeCreated.badge_type !== ContributorStatus.Verified) {
       openSearchPanelAndSearchContributors();
     }
   }, [


### PR DESCRIPTION
Jeg slår av begrensningen på auto-søk selv for monsterposter - da Gunvald mener det aldri vil komme poster med mer enn ~10 norske forfattere. 
Poster med mellom 30 og 100 forfattere vil uansett bare vise max 30 av gangen før man må bla